### PR TITLE
Added UUID for tracing a single method invocation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.3.3
+
+* Added joinpoint UUID for tracing a single method invocation. 
+
 ### 1.3.2
 
 * * Update `package.json` to use `"repository"` to avoid npm warnings.

--- a/docs/api.md
+++ b/docs/api.md
@@ -68,6 +68,10 @@ joinpoint = {
 	
 	// Name of the original method
 	method: String,
+	
+	// UUID to trace a single method invocation
+	uuid: String, 
+	
 
 	// When, called, causes the original method to be invoked
 	// When called without arguments, the original arguments will

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -117,6 +117,7 @@ A joinpoint has the following properties:
 * target - context with which the original method was called
 * method - String name of the method that was called
 * args - Array of arguments that were passed to the method
+* uuid - UUID for tracing a single method invocation
 
 ## Accessing the Joinpoint
 

--- a/meld.js
+++ b/meld.js
@@ -120,7 +120,8 @@ define(function () {
 			joinpoint = pushJoinpoint({
 				target: context,
 				method: func,
-				args: args
+				args: args,
+				uuid: generateUUID()
 			});
 
 			try {
@@ -160,6 +161,18 @@ define(function () {
 			function callAfter(afterType, args) {
 				advisor._callSimpleAdvice(afterType, context, args);
 			}
+
+			function generateUUID() {
+				var d = new Date().getTime();
+				var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+					var r = (d + Math.random()*16)%16 | 0;
+					d = Math.floor(d/16);
+					return (c=='x' ? r : (r&0x3|0x8)).toString(16);
+				});
+
+				return uuid;
+			}
+
 		};
 
 		defineProperty(advised, '_advisor', { value: advisor, configurable: true });

--- a/test/joinpoint.js
+++ b/test/joinpoint.js
@@ -107,6 +107,33 @@ buster.testCase('joinpoint', {
 			assert.equals(meldJoinpoint.args, expected);
 		}
 
+	},
+
+	'should identify advised function stack': function() {
+		var target, expected;
+
+		target = {
+			method: function() {}
+		};
+
+		expected = [1, 2, 3];
+
+		meld.before(target, 'method', verifyJoinpoint);
+		meld.on(target, 'method', verifyJoinpoint);
+		meld.afterReturning(target, 'method', verifyJoinpoint);
+		meld.after(target, 'method', verifyJoinpoint);
+
+		target.method.apply(target, expected);
+
+		refute.defined(meld.joinpoint());
+
+		function verifyJoinpoint() {
+			var jp = meld.joinpoint();
+			assert.equals(jp.target, target);
+			assert.equals(jp.method, 'method');
+			assert.equals(jp.args, expected);
+			assert.defined(jp.uuid);
+		}
 	}
 
 });


### PR DESCRIPTION
Joinpoint UUID would help tracing a single method invocation in calling application. For example, to store start time in "before" advice and calculate elapsed time in "after" advice - having UUID would let application to cache method invocation details and easily identify them. 